### PR TITLE
fix: fix potential internal server error trigger by nest lifecycle

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,13 @@ module.exports = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-unused-vars': [
+      'warn',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+      },
+    ],
   },
 };

--- a/src/cores/constants/index.ts
+++ b/src/cores/constants/index.ts
@@ -1,0 +1,1 @@
+export const INTERNAL_APIS = ['/health', '/metrics'];

--- a/src/cores/interceptors/responseLog.interceptor.ts
+++ b/src/cores/interceptors/responseLog.interceptor.ts
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 import { Response } from 'express';
 
+import { INTERNAL_APIS } from '#cores/constants';
 import { InternalRequest } from '#cores/types';
 import { CustomLog } from '#logger/appLog.service';
 
@@ -16,34 +17,23 @@ import { CustomLog } from '#logger/appLog.service';
  * If endpoint is blacklisted, take k8s health check endpoint for example, it will not log the request and response.
  */
 @Injectable()
-export class LogInterceptor implements NestInterceptor {
-  private readonly blacklist: Array<string> = ['/health', '/metrics'];
-
+export class ResponseLoggerInterceptor implements NestInterceptor {
   constructor(private readonly logger: CustomLog) {}
 
   private isBlacklisted(url: string): boolean {
-    return this.blacklist.some((blacklistedUrl) =>
-      url.includes(blacklistedUrl),
-    );
+    return INTERNAL_APIS.some((blacklistedUrl) => url.includes(blacklistedUrl));
   }
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const request: InternalRequest = context.switchToHttp().getRequest();
-    const requestId: string = request.locals.requestId;
-    const { method, url } = request;
+    const { url } = request;
 
     // early return if endpoint is blacklisted
     if (this.isBlacklisted(url)) return next.handle();
 
-    this.logger.log(
-      requestId,
-      `Request, ${method}, ${url}, ${JSON.stringify(
-        request.headers,
-      )}, ${JSON.stringify(request.body)}`,
-    );
-
     return next.handle().pipe(
       tap((data) => {
+        const requestId: string = request.locals.requestId;
         const response: Response = context.switchToHttp().getResponse();
         const { statusCode } = response;
         this.logger.log(

--- a/src/cores/middlewares/requestId.middleware.ts
+++ b/src/cores/middlewares/requestId.middleware.ts
@@ -1,0 +1,20 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { v4 as uuidv4 } from 'uuid';
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * @description  is a interceptor to help generate request id.
+ * It will be place at the beginning of the request and store the request id in the request locals.
+ */
+@Injectable()
+export class RequestIdMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    const headerName = 'X-Request-Id';
+    const headerId = req.get(headerName);
+    const requestId = headerId ? headerId : uuidv4();
+
+    req.locals = req.locals || {};
+    req.locals.requestId = requestId;
+    next();
+  }
+}

--- a/src/cores/middlewares/requestLog.middleware.ts
+++ b/src/cores/middlewares/requestLog.middleware.ts
@@ -1,0 +1,22 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Response, NextFunction } from 'express';
+
+import { InternalRequest } from '#cores/types';
+import { CustomLog } from '#logger/appLog.service';
+
+@Injectable()
+export class RequestLoggerMiddleware implements NestMiddleware {
+  constructor(private readonly logger: CustomLog) {}
+
+  use(req: InternalRequest, _res: Response, next: NextFunction) {
+    const requestId = req.locals.requestId;
+    const { method, url, headers, body } = req;
+
+    this.logger.log(
+      requestId,
+      `Request, ${method}, ${url}, ${JSON.stringify(headers)}, ${JSON.stringify(body)}`,
+    );
+
+    next();
+  }
+}

--- a/src/modules/app/app.module.ts
+++ b/src/modules/app/app.module.ts
@@ -1,9 +1,16 @@
-import { Module } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
 import { APP_FILTER, APP_INTERCEPTOR } from '@nestjs/core';
 
+import { INTERNAL_APIS } from '#cores/constants';
 import { AllExceptionsFilter } from '#cores/exceptions/general.exception';
-import { RequestIdInterceptor } from '#cores/interceptors/requestId.interceptor';
-import { LogInterceptor } from '#cores/interceptors/responseLog.interceptor';
+import { ResponseLoggerInterceptor } from '#cores/interceptors/responseLog.interceptor';
+import { RequestIdMiddleware } from '#cores/middlewares/requestId.middleware';
+import { RequestLoggerMiddleware } from '#cores/middlewares/requestLog.middleware';
 import { AppController } from '#app/app.controller';
 import { HeroModule } from '#hero/hero.module';
 import { HeroController } from '#hero/hero.controller';
@@ -14,10 +21,21 @@ import { LoggerModule } from '#logger/logger.module';
   imports: [LoggerModule, HeroModule],
   controllers: [HeroController, AppController],
   providers: [
-    { provide: APP_INTERCEPTOR, useClass: RequestIdInterceptor },
-    { provide: APP_INTERCEPTOR, useClass: LogInterceptor },
+    { provide: APP_INTERCEPTOR, useClass: ResponseLoggerInterceptor },
     { provide: APP_FILTER, useClass: AllExceptionsFilter },
     CustomLog,
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    const excludedRoutes = INTERNAL_APIS.map((url) => ({
+      path: url,
+      method: RequestMethod.GET,
+    }));
+
+    consumer
+      .apply(RequestIdMiddleware, RequestLoggerMiddleware)
+      .exclude(...excludedRoutes)
+      .forRoutes('*');
+  }
+}


### PR DESCRIPTION
### Hero project pull request

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you successfully ran tests with your changes locally?
- [x] Have you lint your code locally prior to submission?

### Explanation
In the previous implementation, we set the `requestId` and request/response `logger` in an **interceptor**. However, when testing the API with this setup, we discovered that the **interceptor takes effect after the guard**. This lifecycle order can potentially lead to **Internal Server Error** when a **guard** throws an **Unauthorized Exception**, as the guard cannot access the requestId to log the response.

### Update
To address this issue, we refactored the NestJS component lifecycle by setting the requestId and request log in **middleware**, which takes effect before the **guard**.

